### PR TITLE
remove unnecessary & ~0x7

### DIFF
--- a/popcount.h
+++ b/popcount.h
@@ -125,7 +125,7 @@ inline int select64_broadword(uint64 x, int k) {
     
     // Phase 2: compare each byte sum with the residual
     const uint64 residual_step_8 = residual * ONES_STEP_8;
-    const int place = ( LEQ_STEP_8( byte_sums, residual_step_8 ) * ONES_STEP_8 >> 53 ) & ~0x7;
+    const int place = ( LEQ_STEP_8( byte_sums, residual_step_8 ) * ONES_STEP_8 >> 53 );
     
     // Phase 3: Locate the relevant byte and make 8 copies with incremental masks
     const int byte_rank = residual - ( ( ( byte_sums << 8 ) >> place ) & 0xFF );


### PR DESCRIPTION
It is easy to prove we do not need `& ~0x7` because the maximum value it can operate on is `00001000_00000111_00000110_00000101_00000100_00000011_00000010_00000001 >> 53`. Since the byte under the most significant byte can be a 7 at most, the upper 3 bits of that second byte are always 0. Therefore we do not need to zero them out.